### PR TITLE
Add Padding to Content to Show Last Item

### DIFF
--- a/dist/css/sth-select.css
+++ b/dist/css/sth-select.css
@@ -50,6 +50,7 @@
   cursor: pointer;
   max-height: 100%;
   overflow-y: auto;
+  padding-bottom: 50px;
 }
 .sth-select-popup .sth-select-title {
   background-color: #d2d2d2;

--- a/src/less/_popup.less
+++ b/src/less/_popup.less
@@ -3,7 +3,7 @@
  *******************************/
 .sth-select-popup {
 	background-color: white;
-	
+
 	bottom: 0;
 	height: 0;
 	left: 0;
@@ -16,6 +16,7 @@
 		cursor: pointer;
 		max-height: 100%;
 		overflow-y: auto;
+		padding-bottom: 50px;
 	}
 
 	.sth-select-title {


### PR DESCRIPTION
- With the height of the `sth-select-content` being managed by jquery, the panel needs to recompensate for the remaining 50px. Adding a padding-bottom of 50px fixes the issue and also will not affect the list if the list is longer than the example provides. Hope you like!