### PR TITLE
Update for devices with height < 500px

### DIFF
--- a/dist/js/sth-select.js
+++ b/dist/js/sth-select.js
@@ -167,7 +167,7 @@
 			var titleHeight = _$title.outerHeight();
 
 			var contentHeight = allItemsHeight + titleHeight;
-			return contentHeight < MAX_HEIGHT ? contentHeight : MAX_HEIGHT;
+			return contentHeight < MAX_HEIGHT ? contentHeight : MAX_HEIGHT <= $(window).height() ? MAX_HEIGHT : $(window).height();
 		}
 
 		/**


### PR DESCRIPTION
 #3  Since, the `MAX_HEIGHT` is set to `500` by default, problems in the devices with less than `500px` height will arise. So, in these devices there must be a workaround. I have added a check that verifies whether the `MAX_HEIGHT` is less than the window's height. If it is, then simply return the `MAX_HEIGHT`, else, return the window's height.